### PR TITLE
Cache source maps on disk

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,7 +1,39 @@
-fs = require 'fs'
+crypto = require 'crypto'
+fs = require 'fs-plus'
 path = require 'path'
-CoffeeScript = require 'coffee-script'
-{SourceMapConsumer} = require 'source-map'
+
+CoffeeScriptVersion = require('coffee-script/package.json').version
+CoffeeScript = null # defer until used
+SourceMapConsumer = null # defer until used
+
+cachePath = null
+
+getCachePath = (code) ->
+  return unless cachePath
+
+  digest = crypto.createHash('sha1').update(code, 'utf8').digest('hex')
+  path.join(cachePath, CoffeeScriptVersion, "#{digest}.map")
+
+getCachedSourceMap = (codeCachePath) ->
+  if fs.isFileSync(codeCachePath)
+    try
+      return fs.readFileSync(codeCachePath, 'utf8')
+
+  return
+
+writeSourceMapToCache = (codeCachePath, sourceMap) ->
+  if codeCachePath
+    try
+      fs.writeFileSync(codeCachePath, sourceMap)
+
+  return
+
+compileSourceMap = (code, filePath, codeCachePath) ->
+  CoffeeScript ?= require 'coffee-script'
+  {v3SourceMap} = CoffeeScript.compile(code, {sourceMap: true, filename: filePath})
+
+  writeSourceMapToCache(codeCachePath, v3SourceMap)
+  v3SourceMap
 
 convertLine = (filePath, line, column, sourceMaps={}) ->
   try
@@ -11,11 +43,13 @@ convertLine = (filePath, line, column, sourceMaps={}) ->
         sourceMapContents =  fs.readFileSync(sourceMapPath, 'utf8')
       else
         code = fs.readFileSync(filePath, 'utf8')
-        {v3SourceMap} = CoffeeScript.compile(code, {sourceMap: true, filename: filePath})
-        sourceMapContents = v3SourceMap
+        codeCachePath = getCachePath(code)
+        sourceMapContents = getCachedSourceMap(codeCachePath)
+        sourceMapContents ?= compileSourceMap(code, filePath, codeCachePath)
 
     if sourceMapContents
       sourceMaps[filePath] = sourceMapContents
+      SourceMapConsumer ?= require('source-map').SourceMapConsumer
       sourceMap = new SourceMapConsumer(sourceMapContents)
       position = sourceMap.originalPositionFor({line, column})
       if position.line? and position.column?
@@ -48,4 +82,6 @@ convertStackTrace = (stackTrace, sourceMaps={}) ->
 
   convertedLines.join('\n')
 
-module.exports = {convertLine, convertStackTrace}
+exports.convertLine = convertLine
+exports.convertStackTrace = convertStackTrace
+exports.setCacheDirectory = (newCachePath) -> cachePath = newCachePath

--- a/index.coffee
+++ b/index.coffee
@@ -12,7 +12,7 @@ getCachePath = (code) ->
   return unless cachePath
 
   digest = crypto.createHash('sha1').update(code, 'utf8').digest('hex')
-  path.join(cachePath, CoffeeScriptVersion, "#{digest}.map")
+  path.join(cachePath, CoffeeScriptVersion, "#{digest}.json")
 
 getCachedSourceMap = (codeCachePath) ->
   if fs.isFileSync(codeCachePath)

--- a/index.coffee
+++ b/index.coffee
@@ -35,6 +35,11 @@ compileSourceMap = (code, filePath, codeCachePath) ->
   writeSourceMapToCache(codeCachePath, v3SourceMap)
   v3SourceMap
 
+getSourceMapPosition = (sourceMapContents, line, column)->
+  SourceMapConsumer ?= require('source-map').SourceMapConsumer
+  sourceMap = new SourceMapConsumer(sourceMapContents)
+  sourceMap.originalPositionFor({line, column})
+
 convertLine = (filePath, line, column, sourceMaps={}) ->
   try
     unless sourceMapContents = sourceMaps[filePath]
@@ -49,9 +54,7 @@ convertLine = (filePath, line, column, sourceMaps={}) ->
 
     if sourceMapContents
       sourceMaps[filePath] = sourceMapContents
-      SourceMapConsumer ?= require('source-map').SourceMapConsumer
-      sourceMap = new SourceMapConsumer(sourceMapContents)
-      position = sourceMap.originalPositionFor({line, column})
+      position = getSourceMapPosition(sourceMapContents, line, column)
       if position.line? and position.column?
         if position.source and position.source isnt '.'
           source = path.resolve(filePath, '..',  position.source)

--- a/index.coffee
+++ b/index.coffee
@@ -31,7 +31,6 @@ writeSourceMapToCache = (codeCachePath, sourceMap) ->
 compileSourceMap = (code, filePath, codeCachePath) ->
   CoffeeScript ?= require 'coffee-script'
   {v3SourceMap} = CoffeeScript.compile(code, {sourceMap: true, filename: filePath})
-
   writeSourceMapToCache(codeCachePath, v3SourceMap)
   v3SourceMap
 

--- a/package.json
+++ b/package.json
@@ -29,15 +29,17 @@
   },
   "dependencies": {
     "coffee-script": "~1.8.0",
+    "fs-plus": "^2.5.0",
     "source-map": "~0.1.43"
   },
   "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.9",
+    "grunt-coffeelint": "0.0.7",
+    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-shell": "~0.3.0",
     "jasmine-focused": "1.x",
     "rimraf": "~2.2.0",
-    "grunt-cli": "~0.1.9",
-    "grunt": "~0.4.1",
-    "grunt-contrib-coffee": "~0.7.0",
-    "grunt-coffeelint": "0.0.7",
-    "grunt-shell": "~0.3.0"
+    "temp": "^0.8.1"
   }
 }

--- a/spec/coffeestack-spec.coffee
+++ b/spec/coffeestack-spec.coffee
@@ -49,7 +49,7 @@ describe 'CoffeeStack', ->
           at Test.module.exports.Test.fail (#{__dirname}/fixtures/test.coffee:10:15)"""
 
   describe 'source map caching', ->
-    it 'stores compiled source maps the cache and uses them on subsequeunt calls', ->
+    it 'stores compiled source maps and uses them on subsequeunt calls', ->
       CoffeeScript = require 'coffee-script'
       spyOn(CoffeeScript, 'compile').andCallThrough()
 

--- a/spec/coffeestack-spec.coffee
+++ b/spec/coffeestack-spec.coffee
@@ -1,5 +1,8 @@
 path = require 'path'
-{convertLine, convertStackTrace} = require '../index'
+temp = require 'temp'
+{convertLine, convertStackTrace, setCacheDirectory} = require '../index'
+
+temp.track()
 
 describe 'CoffeeStack', ->
   describe 'convertLine(filePath, line, column)', ->
@@ -44,3 +47,18 @@ describe 'CoffeeStack', ->
       expect(convertStackTrace(stackTrace)).toBe """
         Error: this is an error
           at Test.module.exports.Test.fail (#{__dirname}/fixtures/test.coffee:10:15)"""
+
+  describe 'source map caching', ->
+    it 'stores compiled source maps the cache and uses them on subsequeunt calls', ->
+      CoffeeScript = require 'coffee-script'
+      spyOn(CoffeeScript, 'compile').andCallThrough()
+
+      cacheDir = temp.mkdirSync('coffeestack-cache')
+      setCacheDirectory(cacheDir)
+
+      filePath = path.join(__dirname, 'fixtures', 'test.coffee')
+      expect(convertLine(filePath, 4, 2)).toEqual {line: 1, column: 0, source: filePath}
+      expect(CoffeeScript.compile.callCount).toBe 1
+
+      expect(convertLine(filePath, 4, 2)).toEqual {line: 1, column: 0, source: filePath}
+      expect(CoffeeScript.compile.callCount).toBe 1


### PR DESCRIPTION
Support on-disk caching of source maps based on a SHA-1 of the raw CoffeeScript contents.
