### PR TITLE
Upgrade fs-plus to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.8.0",
-    "fs-plus": "^2.5.0",
+    "fs-plus": "^3.1.1",
     "source-map": "~0.1.43"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades the `fs-plus` dependency to get rid of the deprecation warnings that appear on the console when running this module on Node v10.

More info: https://github.com/atom/fs-plus/pull/46